### PR TITLE
[minor enhancement] Display Amount of Apples used

### DIFF
--- a/regular.lua
+++ b/regular.lua
@@ -100,6 +100,8 @@ end
 local function Menu()
 	battle.resetState()
 	turnCounter = {0, 0, 0, 0, 0}
+	-- Prints a message containing the amount of apple used
+	toast(StoneUsed)
 
 	--Click uppermost quest.
 	click(game.MENU_SELECT_QUEST_CLICK)


### PR DESCRIPTION
After completing run, when clicking on next run, displays the current amount of apple that was used in a toast.
Useful to users who leave their phones on and come back later to check how much apples they have already used.